### PR TITLE
fix: compromised docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - 3000:3000
   postgres:
-    image: postgres:12-alpine
+    image: postgres:17-alpine
     environment:
       POSTGRES_PASSWORD: $PGPASSWORD
     ports:


### PR DESCRIPTION
Looks like postgres:12-alpine contains malware. It is not a tag for official 'postgres' image anymore. Upgrading to 17-alpine, which is on the list