### PR TITLE
feat: properly set transaction threshold

### DIFF
--- a/src/lib/threshold.ts
+++ b/src/lib/threshold.ts
@@ -1,0 +1,83 @@
+import { AccountResponse, Operation, OperationType, Transaction } from 'stellar-sdk';
+
+export type ThresholdLevel = 'low' | 'med' | 'high';
+
+const thresholdMap: Record<OperationType, ThresholdLevel> = {
+  createAccount: 'med',
+  payment: 'med',
+  pathPaymentStrictReceive: 'med',
+  pathPaymentStrictSend: 'med',
+  manageSellOffer: 'high',
+  manageBuyOffer: 'high',
+  createPassiveSellOffer: 'high',
+  setOptions: 'high',
+  changeTrust: 'med',
+  allowTrust: 'low',
+  accountMerge: 'high',
+  inflation: 'low',
+  manageData: 'med',
+  bumpSequence: 'low',
+  createClaimableBalance: 'med',
+  claimClaimableBalance: 'med',
+  beginSponsoringFutureReserves: 'low',
+  endSponsoringFutureReserves: 'low',
+  revokeSponsorship: 'high',
+  // TODO: upgrade stellar sdk to latest version to support these operations
+  //clawback: 'high',
+  //clawbackClaimableBalance: 'high',
+  //setTrustLineFlags: 'high',
+  //invokeHostFunction: 'high', // if using Soroban
+  //extendFootprintTtl: 'low',  // if using Soroban
+  //restoreFootprint: 'low',    // if using Soroban
+};
+
+const thresholdValues: Record<ThresholdLevel, number> = {
+  low: 1,
+  med: 2,
+  high: 3,
+};
+
+const reverseThresholdValues: Record<number, ThresholdLevel> = {
+  1: 'low',
+  2: 'med',
+  3: 'high',
+};
+
+export function getAccountThreshold(account: AccountResponse, threshold: ThresholdLevel): number {
+  switch (threshold) {
+    case 'low':
+      return account.thresholds.low_threshold
+    case 'med':
+      return account.thresholds.med_threshold
+    case 'high':
+      return account.thresholds.high_threshold
+    default:
+      return account.thresholds.high_threshold
+  }
+}
+
+/**
+ * Determines the highest threshold level required to authorize a Stellar transaction.
+ * @param tx A Stellar Transaction object.
+ * @returns 'low', 'med', or 'high'
+ */
+export function getRequiredThreshold(operations: Operation[]): ThresholdLevel {
+  let maxThresholdValue = 0;
+
+  for (const op of operations) {
+    const opType = op.type;
+    const level = thresholdMap[opType] || 'high'; // default to 'high' for unknown
+    const numericValue = thresholdValues[level];
+    maxThresholdValue = Math.max(maxThresholdValue, numericValue);
+  }
+
+  return reverseThresholdValues[maxThresholdValue] || 'high';
+}
+
+export function getAccountTransactionThreshold(sourceAccount: AccountResponse, transaction: Transaction): number {
+  const sourceAccountOps = transaction.operations.filter(op => !op.source || op.source === sourceAccount.account_id)
+  const opsThreshold = getRequiredThreshold(sourceAccountOps)
+  const accountThreshold = getAccountThreshold(sourceAccount, opsThreshold)
+  return accountThreshold
+}
+


### PR DESCRIPTION
For each of the source accounts in transaction we are now checking what's the largest operation threshold in it and set it to `key_weight_threshold`.

This allows `hasSufficientSignatures` check to [work](https://github.com/SunceWallet/signature-coordinator/blob/f14fe5b2fd1fedd389d7d34b1293ca3b7d6caea3/src/lib/records.ts#L27) properly in collate.ts and submit.ts (when we add the next signature or try to submit).

Changed here:
- `hasSufficientSignatures` in `create.ts` wasn't working before (`tx.signatures` are always empty here!). I made it work and renamed to `signatureIsSufficient` to reflect the fact that we check only one signature (we don't have others at this point as this is only creation of multisig tx)
- create a helper set of functions in `threshold.ts`. Most important is `getAccountTransactionThreshold` which for a given account and tx returns the max threshold of the operations on account in this tx.
- using `getAccountTransactionThreshold` to set `key_weight_threshold` for signature request source accounts in database